### PR TITLE
Added support for sha256 hashing

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1" // #nosec
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
@@ -147,5 +148,15 @@ func Sha1Hash(data string) string {
 	if err != nil {
 		panic(err)
 	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func Sha256Hash(data string) string {
+	h := sha256.New()
+	_, err := h.Write([]byte(data))
+	if err != nil {
+		panic(err)
+	}
+
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/loxone.go
+++ b/loxone.go
@@ -626,14 +626,17 @@ func (l *Loxone) handleBinaryEvent(binaryEvent *[]byte, eventType events.EventTy
 }
 
 func (e *encrypt) hashUser(user string, password string, salt string, oneTimeSalt string, hashAlg HashAlg) string {
+	//
 	var hash string
-	switch hashAlg {
+	passwordSalt := fmt.Sprintf("%s:%s", password, salt)
+
 	// create a SHA1/SHA256 hash of the (salted) password
+	switch hashAlg {
 	case SHA1:
-		hash = strings.ToUpper(crypto.Sha1Hash(fmt.Sprintf("%s:%s", password, salt)))
+		hash = strings.ToUpper(crypto.Sha1Hash(passwordSalt))
 		break
 	case SHA256:
-		hash = strings.ToUpper(crypto.Sha256Hash(fmt.Sprintf("%s:%s", password, salt)))
+		hash = strings.ToUpper(crypto.Sha256Hash(passwordSalt))
 		break
 	}
 

--- a/loxone.go
+++ b/loxone.go
@@ -635,8 +635,6 @@ func (e *encrypt) hashUser(user string, password string, salt string, oneTimeSal
 	case SHA256:
 		hash = strings.ToUpper(crypto.Sha256Hash(fmt.Sprintf("%s:%s", password, salt)))
 		break
-	default:
-		hash = strings.ToUpper(crypto.Sha1Hash(fmt.Sprintf("%s:%s", password, salt)))
 	}
 
 	// hash with user and otSalt

--- a/loxone.go
+++ b/loxone.go
@@ -169,9 +169,28 @@ type token struct {
 	unsecurePass bool
 }
 
+// HashAlg defines the algorithm used to hash some user
+// information during token generation
+type HashAlg string
+
+const (
+	SHA1   = "SHA1"
+	SHA256 = "SHA256"
+)
+
+// Valid checks for valid & supported hash algorithms. The
+// value for the algorithm is returned by the miniserver within
+// the process of getting an auth-token and will be used for
+// hashing {password}:{userSalt} and {user}:{pwHash} within
+// createToken() / hashUser()
+func (ha HashAlg) Valid() bool {
+	return (ha == SHA1 || ha == SHA256) && len(ha) > 0
+}
+
 type salt struct {
-	OneTimeSalt string `mapstructure:"key"`
-	Salt        string `mapstructure:"Salt"`
+	OneTimeSalt   string  `mapstructure:"key"`
+	Salt          string  `mapstructure:"Salt"`
+	HashAlgorithm HashAlg `mapstructure:"hashAlg"`
 }
 
 type encryptType int32
@@ -469,7 +488,11 @@ func (l *Loxone) createToken(user string, password string, uniqueID string) erro
 		return err
 	}
 
-	hash := l.encrypt.hashUser(user, password, salt.Salt, salt.OneTimeSalt)
+	if !salt.HashAlgorithm.Valid() {
+		return fmt.Errorf("unsupported hash alogrithm given. For now only '%s' and '%s' are supported", SHA1, SHA256)
+	}
+
+	hash := l.encrypt.hashUser(user, password, salt.Salt, salt.OneTimeSalt, salt.HashAlgorithm)
 
 	cmd = fmt.Sprintf(getToken, hash, user, 4, uniqueID, "GO")
 
@@ -602,9 +625,19 @@ func (l *Loxone) handleBinaryEvent(binaryEvent *[]byte, eventType events.EventTy
 	}
 }
 
-func (e *encrypt) hashUser(user string, password string, salt string, oneTimeSalt string) string {
-	// create a SHA1 hash of the (salted) password
-	hash := strings.ToUpper(crypto.Sha1Hash(fmt.Sprintf("%s:%s", password, salt)))
+func (e *encrypt) hashUser(user string, password string, salt string, oneTimeSalt string, hashAlg HashAlg) string {
+	var hash string
+	switch hashAlg {
+	// create a SHA1/SHA256 hash of the (salted) password
+	case SHA1:
+		hash = strings.ToUpper(crypto.Sha1Hash(fmt.Sprintf("%s:%s", password, salt)))
+		break
+	case SHA256:
+		hash = strings.ToUpper(crypto.Sha256Hash(fmt.Sprintf("%s:%s", password, salt)))
+		break
+	default:
+		hash = strings.ToUpper(crypto.Sha1Hash(fmt.Sprintf("%s:%s", password, salt)))
+	}
 
 	// hash with user and otSalt
 	return crypto.ComputeHmac256(fmt.Sprintf("%s:%s", user, hash), oneTimeSalt)


### PR DESCRIPTION
This pull-request will add support for some miniservers where the hash algorithm that should be used for hashing {user}:{pwHash} should be SHA256 instead of SHA1. The algorithm that should be used are coming from the `/jdev/sys/getkey2/{user}` request within the `LL.value.hashAlg` field.

This will solve #18